### PR TITLE
Fix instantiation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,5 @@ WORKDIR /opt
 COPY requirements.txt requirements.txt
 RUN pip install -r requirements.txt
 COPY wait_for_terraform_plan_approval.py .
+ENV PYTHONPATH=/opt
 ENTRYPOINT ["python", "-m", "wait_for_terraform_plan_approval"]

--- a/wait_for_terraform_plan_approval.py
+++ b/wait_for_terraform_plan_approval.py
@@ -8,7 +8,7 @@ import requests
 
 external_service_url = os.getenv('INPUT_EXTERNAL_SERVICE_URL')
 if not external_service_url:
-	print('`plan_id` is required.')
+	print('`external_service_url` is required.')
 
 
 def submit(plan_contents: str):


### PR DESCRIPTION
Running as a GitHub Action was resulting in this error:

```
/usr/local/bin/python: No module named wait_for_terraform_plan_approval
```

because the Docker instantiation includes `--workdir /github/workspace`. The `python -m wait_for_terraform_plan_approval` doesn't know how to find the script in `/opt`.

This fixes it by adding `PYTHONPATH=/opt` in the Dockerfile, so it will work regardless of the working directory.